### PR TITLE
[APPFW] Add XML documentation and inhouse markers for Team Application

### DIFF
--- a/src/Tizen.Applications.Team/CultureInfoHelper.cs
+++ b/src/Tizen.Applications.Team/CultureInfoHelper.cs
@@ -20,6 +20,9 @@ using System.Runtime.InteropServices;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Resolves culture names from the platform-provided CultureInfo INI file.
+    /// </summary>
     internal static class CultureInfoHelper
     {
         private const string _pathCultureInfoIni = "/usr/share/dotnet.tizen/framework/i18n/CultureInfo.ini";

--- a/src/Tizen.Applications.Team/GSourceManager.cs
+++ b/src/Tizen.Applications.Team/GSourceManager.cs
@@ -19,6 +19,9 @@ using System.Collections.Concurrent;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Posts actions onto the GLib main loop used by the Team application.
+    /// </summary>
     internal static class GSourceManager
     {
         private static readonly GSourceContext _tizenContext = new GSourceContext();
@@ -39,6 +42,9 @@ namespace Tizen.Applications
         }
     }
 
+    /// <summary>
+    /// Holds the GLib source state and action queue for a single main loop context.
+    /// </summary>
     internal class GSourceContext
     {
         private readonly ConcurrentQueue<Action> _actionQueue = new ConcurrentQueue<Action>();

--- a/src/Tizen.Applications.Team/ResourceControl.cs
+++ b/src/Tizen.Applications.Team/ResourceControl.cs
@@ -16,10 +16,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents the resource control information for a Team application.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class ResourceControl
     {
         internal ResourceControl(string resourceType, string minResourceVersion, string maxResourceVersion, bool isAutoClose)
@@ -30,12 +36,32 @@ namespace Tizen.Applications
             IsAutoClose = isAutoClose;
         }
 
+        /// <summary>
+        /// Gets the resource type.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ResourceType { get; }
 
+        /// <summary>
+        /// Gets the minimum version of the required resource package.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string MinResourceVersion { get; }
 
+        /// <summary>
+        /// Gets the maximum version of the required resource package.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string MaxResourceVersion { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the resource is auto-closed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsAutoClose { get; }
     }
 }

--- a/src/Tizen.Applications.Team/SystemLocaleConverter.cs
+++ b/src/Tizen.Applications.Team/SystemLocaleConverter.cs
@@ -24,6 +24,9 @@ using System.Threading.Tasks;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Converts Tizen system locale strings into <see cref="CultureInfo"/> values with ICU fallback.
+    /// </summary>
     internal class SystemLocaleConverter
     {
         private static readonly string LogTag = "DN_TAM";
@@ -151,6 +154,9 @@ namespace Tizen.Applications
         }
 
 
+        /// <summary>
+        /// Wraps ICU uloc_* interop for parsing and canonicalizing locale strings.
+        /// </summary>
         internal class ULocale
         {
             private const int ULOC_FULLNAME_CAPACITY = 157;

--- a/src/Tizen.Applications.Team/TeamApplication.cs
+++ b/src/Tizen.Applications.Team/TeamApplication.cs
@@ -15,10 +15,20 @@
  */
 
 using System;
+using System.ComponentModel;
 using Tizen.Applications.CoreBackend;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents the abstract base class of a Team application instance.
+    /// </summary>
+    /// <remarks>
+    /// A Team application is a member instance managed by the Team host process. Each instance
+    /// owns its own lifecycle, directory information, and application information.
+    /// </remarks>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class TeamApplication : IDisposable
     {
         internal const string LogTag = "DN_TAM";
@@ -27,16 +37,34 @@ namespace Tizen.Applications
 
         private TeamDirectoryInfo _directoryInfo;
         private TeamApplicationInfo _applicationInfo;
+
+        /// <summary>
+        /// The backend that drives this Team application instance.
+        /// </summary>
         protected readonly TeamCoreBackend _backend;
 
+        /// <summary>
+        /// Gets the backend associated with this Team application instance.
+        /// </summary>
         protected ICoreBackend Backend => _backend;
 
+        /// <summary>
+        /// Initializes the <see cref="TeamApplication"/> class with the given backend.
+        /// </summary>
+        /// <param name="backend">The backend used to drive this Team application instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="backend"/> is null.</exception>
         protected TeamApplication(TeamCoreBackend backend)
         {
             Log.Info(LogTag, "TeamApplication constructor called");
             _backend = backend ?? throw new ArgumentNullException(nameof(backend));
         }
 
+        /// <summary>
+        /// Gets the directory information of the current Team application instance.
+        /// </summary>
+        /// <value>A <see cref="TeamDirectoryInfo"/> instance, or <c>null</c> if the member handle is not yet available.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamDirectoryInfo DirectoryInfo
         {
             get
@@ -57,6 +85,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the application information of the current Team application instance.
+        /// </summary>
+        /// <value>A <see cref="TeamApplicationInfo"/> instance, or <c>null</c> if the member handle or application id cannot be resolved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamApplicationInfo ApplicationInfo
         {
             get
@@ -89,8 +123,20 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the current Team application instance.
+        /// </summary>
+        /// <value>The current <see cref="TeamApplication"/> instance.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamApplication Current { get { return this; } }
 
+        /// <summary>
+        /// Gets the name of the current Team application instance.
+        /// </summary>
+        /// <value>The name string, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Name
         {
             get
@@ -113,6 +159,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the version of the current Team application instance.
+        /// </summary>
+        /// <value>The version string, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Version
         {
             get
@@ -135,6 +187,13 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Runs the Team application's main loop and registers this instance with the Team manager.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="args"/> is null.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void Run(string[] args)
         {
             if (args == null)
@@ -144,6 +203,11 @@ namespace Tizen.Applications
             TeamManager.RegisterRunningTeamApp(this);
         }
 
+        /// <summary>
+        /// Exits the main loop of this Team application instance and unregisters it from the Team manager.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void Exit()
         {
             TeamManager.UnRegisterRunningTeamApp(this);
@@ -152,6 +216,10 @@ namespace Tizen.Applications
 
         private bool _disposedValue = false;
 
+        /// <summary>
+        /// Releases the resources used by this Team application instance.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -169,11 +237,19 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Finalizes the <see cref="TeamApplication"/> instance.
+        /// </summary>
         ~TeamApplication()
         {
             Dispose(false);
         }
 
+        /// <summary>
+        /// Releases all resources used by this Team application instance.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void Dispose()
         {
             Log.Info(LogTag, "TeamApplication.Dispose() called");

--- a/src/Tizen.Applications.Team/TeamApplicationInfo.cs
+++ b/src/Tizen.Applications.Team/TeamApplicationInfo.cs
@@ -22,6 +22,15 @@ using Tizen.Internals.Errors;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents the installed application information of a Team application instance.
+    /// </summary>
+    /// <remarks>
+    /// The information is obtained lazily from the native application manager and cached for subsequent access.
+    /// Call <see cref="Dispose()"/> to release the underlying native handle.
+    /// </remarks>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamApplicationInfo : IDisposable
     {
         private const string LogTag = "DN_TAMS";
@@ -45,11 +54,20 @@ namespace Tizen.Applications
             _applicationId = applicationId;
         }
 
+        /// <summary>
+        /// Finalizes the <see cref="TeamApplicationInfo"/> instance.
+        /// </summary>
         ~TeamApplicationInfo()
         {
             Dispose(false);
         }
 
+        /// <summary>
+        /// Gets the application id.
+        /// </summary>
+        /// <value>The application id string.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ApplicationId
         {
             get
@@ -58,6 +76,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the package id of the application.
+        /// </summary>
+        /// <value>The package id string, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string PackageId
         {
             get
@@ -76,6 +100,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the label of the application.
+        /// </summary>
+        /// <value>The application label, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Label
         {
             get
@@ -94,6 +124,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the executable file of the application.
+        /// </summary>
+        /// <value>The executable file path, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExecutablePath
         {
             get
@@ -112,6 +148,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the icon image of the application.
+        /// </summary>
+        /// <value>The icon image path, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string IconPath
         {
             get
@@ -130,6 +172,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the application type.
+        /// </summary>
+        /// <value>The application type string, or <see cref="string.Empty"/> if it cannot be retrieved.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ApplicationType
         {
             get
@@ -148,6 +196,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the application component type.
+        /// </summary>
+        /// <value>The <see cref="ApplicationComponentType"/> of this application.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public ApplicationComponentType ComponentType
         {
             get
@@ -166,6 +220,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the metadata key-value pairs declared by the application.
+        /// </summary>
+        /// <value>A dictionary containing the metadata entries.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IDictionary<String, String> Metadata
         {
             get
@@ -198,6 +258,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the application is not displayed on the launcher.
+        /// </summary>
+        /// <value><c>true</c> if the application is hidden from the launcher; otherwise, <c>false</c>.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsNoDisplay
         {
             get
@@ -217,6 +283,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the application is launched automatically on system boot.
+        /// </summary>
+        /// <value><c>true</c> if the application is launched on boot; otherwise, <c>false</c>.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsOnBoot
         {
             get
@@ -235,6 +307,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the application is preloaded on the device.
+        /// </summary>
+        /// <value><c>true</c> if the application is preloaded; otherwise, <c>false</c>.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsPreload
         {
             get
@@ -253,6 +331,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the categories the application belongs to.
+        /// </summary>
+        /// <value>An enumerable collection of category names.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IEnumerable<string> Categories
         {
             get
@@ -281,6 +365,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the directory shared with other applications for this Team member.
+        /// </summary>
+        /// <value>The shared data directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedDataPath
         {
             get
@@ -298,6 +388,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the read-only resource directory shared with other applications for this Team member.
+        /// </summary>
+        /// <value>The shared resource directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedResourcePath
         {
             get
@@ -315,6 +411,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the directory shared only with trusted applications for this Team member.
+        /// </summary>
+        /// <value>The shared trusted directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedTrustedPath
         {
             get
@@ -332,6 +434,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the shared directory on the external storage for this Team member.
+        /// </summary>
+        /// <value>The external shared data directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExternalSharedDataPath
         {
             get
@@ -349,6 +457,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the resource control entries declared by the application.
+        /// </summary>
+        /// <value>An enumerable collection of <see cref="ResourceControl"/> entries.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IEnumerable<ResourceControl> ResourceControls
         {
             get
@@ -376,6 +490,13 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the localized label of the application for the given locale.
+        /// </summary>
+        /// <param name="locale">The locale in the form of language and country code (for example, "en-US").</param>
+        /// <returns>The localized label; falls back to <see cref="Label"/> if no localized value is available.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string GetLocalizedLabel(string locale)
         {
             string label = string.Empty;
@@ -388,6 +509,10 @@ namespace Tizen.Applications
             return label;
         }
 
+        /// <summary>
+        /// Gets the absolute path of the common shared data directory for this Team member.
+        /// </summary>
+        /// <value>The common shared data directory path.</value>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedDataPath
         {
@@ -406,6 +531,10 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path of the common shared trusted directory for this Team member.
+        /// </summary>
+        /// <value>The common shared trusted directory path.</value>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedTrustedPath
         {
@@ -439,6 +568,11 @@ namespace Tizen.Applications
             return _infoHandle;
         }
 
+        /// <summary>
+        /// Releases all resources used by this <see cref="TeamApplicationInfo"/>.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public void Dispose()
         {
             Dispose(true);

--- a/src/Tizen.Applications.Team/TeamApplicationInfo.cs
+++ b/src/Tizen.Applications.Team/TeamApplicationInfo.cs
@@ -513,6 +513,7 @@ namespace Tizen.Applications
         /// Gets the absolute path of the common shared data directory for this Team member.
         /// </summary>
         /// <value>The common shared data directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedDataPath
         {
@@ -535,6 +536,7 @@ namespace Tizen.Applications
         /// Gets the absolute path of the common shared trusted directory for this Team member.
         /// </summary>
         /// <value>The common shared trusted directory path.</value>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedTrustedPath
         {

--- a/src/Tizen.Applications.Team/TeamCoreApplication.cs
+++ b/src/Tizen.Applications.Team/TeamCoreApplication.cs
@@ -15,27 +15,103 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Threading.Tasks;
 using Tizen.Applications.CoreBackend;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents the core Team application with common lifecycle and system events.
+    /// </summary>
+    /// <remarks>
+    /// Subclasses typically add UI- or service-specific behavior on top of the events exposed here.
+    /// </remarks>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamCoreApplication : TeamApplication
     {
+        /// <summary>
+        /// Initializes the <see cref="TeamCoreApplication"/> class with the given backend.
+        /// </summary>
+        /// <param name="backend">The backend used to drive this Team application instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="backend"/> is null.</exception>
         protected TeamCoreApplication(TeamCoreBackend backend) : base(backend)
         {
             Log.Info(LogTag, "TeamCoreApplication constructor called");
         }
+
+        /// <summary>
+        /// Occurs whenever the application is launched.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Created;
+
+        /// <summary>
+        /// Occurs whenever the application is about to shut down.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Terminated;
+
+        /// <summary>
+        /// Occurs whenever the application receives an application control request.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<AppControlReceivedEventArgs> AppControlReceived;
+
+        /// <summary>
+        /// Occurs when a low memory condition is reported by the system.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<LowMemoryEventArgs> LowMemory;
+
+        /// <summary>
+        /// Occurs when a low battery condition is reported by the system.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<LowBatteryEventArgs> LowBattery;
+
+        /// <summary>
+        /// Occurs when the system language is changed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<LocaleChangedEventArgs> LocaleChanged;
+
+        /// <summary>
+        /// Occurs when the region format of the system is changed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<RegionFormatChangedEventArgs> RegionFormatChanged;
+
+        /// <summary>
+        /// Occurs when the device orientation is changed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<DeviceOrientationEventArgs> DeviceOrientationChanged;
+
+        /// <summary>
+        /// Occurs when the system time zone is changed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler<TimeZoneChangedEventArgs> TimeZoneChanged;
+
+        /// <summary>
+        /// Runs the Team application's main loop and subscribes to lifecycle and system events.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="args"/> is null.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Run(string[] args)
         {
             base.Run(args);
@@ -53,6 +129,9 @@ namespace Tizen.Applications
             _backend.Run(args);
         }
 
+        /// <summary>
+        /// Invoked when the application is created. Raises the <see cref="Created"/> event.
+        /// </summary>
         protected virtual void OnCreate()
         {
             if (!GlobalizationMode.Invariant)
@@ -70,12 +149,19 @@ namespace Tizen.Applications
             Created?.Invoke(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Invoked when the application is about to terminate. Raises the <see cref="Terminated"/> event.
+        /// </summary>
         protected virtual void OnTerminate()
         {
             Log.Info(LogTag, "TeamCoreApplication.OnTerminate() called");
             Terminated?.Invoke(this, EventArgs.Empty);
         }
 
+        /// <summary>
+        /// Invoked when the application receives an application control request. Raises the <see cref="AppControlReceived"/> event.
+        /// </summary>
+        /// <param name="e">The event data containing the received application control.</param>
         protected virtual void OnAppControlReceived(AppControlReceivedEventArgs e)
         {
             Log.Info(LogTag, "TeamCoreApplication.OnAppControlReceived() called");
@@ -88,6 +174,11 @@ namespace Tizen.Applications
             AppControlReceived?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Invoked when a low memory event is reported by the system. Raises the <see cref="LowMemory"/> event
+        /// and triggers <see cref="GC.Collect()"/> on soft/hard warnings.
+        /// </summary>
+        /// <param name="e">The event data describing the low memory status.</param>
         protected virtual void OnLowMemory(LowMemoryEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnLowMemory() called - Status: {e?.LowMemoryStatus}");
@@ -104,6 +195,10 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Invoked when a low battery event is reported by the system. Raises the <see cref="LowBattery"/> event.
+        /// </summary>
+        /// <param name="e">The event data describing the low battery status.</param>
         protected virtual void OnLowBattery(LowBatteryEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnLowBattery() called - Status: {e?.LowBatteryStatus}");
@@ -116,6 +211,10 @@ namespace Tizen.Applications
             LowBattery?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Invoked when the system language is changed. Updates the current UI culture and raises the <see cref="LocaleChanged"/> event.
+        /// </summary>
+        /// <param name="e">The event data describing the new locale.</param>
         protected virtual void OnLocaleChanged(LocaleChangedEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnLocaleChanged() called - Locale: {e?.Locale}");
@@ -133,6 +232,10 @@ namespace Tizen.Applications
             LocaleChanged?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Invoked when the region format is changed. Updates the current culture and raises the <see cref="RegionFormatChanged"/> event.
+        /// </summary>
+        /// <param name="e">The event data describing the new region.</param>
         protected virtual void OnRegionFormatChanged(RegionFormatChangedEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnRegionFormatChanged() called - Region: {e?.Region}");
@@ -150,12 +253,20 @@ namespace Tizen.Applications
             RegionFormatChanged?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Invoked when the device orientation is changed. Raises the <see cref="DeviceOrientationChanged"/> event.
+        /// </summary>
+        /// <param name="e">The event data describing the new orientation.</param>
         protected virtual void OnDeviceOrientationChanged(DeviceOrientationEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnDeviceOrientationChanged() called - Orientation: {e?.DeviceOrientation}");
             DeviceOrientationChanged?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Invoked when the system time zone is changed. Clears cached culture data and raises the <see cref="TimeZoneChanged"/> event.
+        /// </summary>
+        /// <param name="e">The event data describing the new time zone.</param>
         protected virtual void OnTimeZoneChanged(TimeZoneChangedEventArgs e)
         {
             Log.Info(LogTag, $"TeamCoreApplication.OnTimeZoneChanged() called - TimeZone: {e?.TimeZone}, ID: {e?.TimeZoneId}");
@@ -163,6 +274,13 @@ namespace Tizen.Applications
             TimeZoneChanged?.Invoke(this, e);
         }
 
+        /// <summary>
+        /// Posts an action to be executed on the main loop of the current Team application.
+        /// </summary>
+        /// <param name="runner">The action to be executed on the main loop.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="runner"/> is null.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Post(Action runner)
         {
             Log.Info(LogTag, "TeamCoreApplication.Post(Action) called");
@@ -174,6 +292,15 @@ namespace Tizen.Applications
             GSourceManager.Post(runner);
         }
 
+        /// <summary>
+        /// Posts a function to be executed on the main loop of the current Team application and awaits its result.
+        /// </summary>
+        /// <typeparam name="T">The type of the result returned by <paramref name="runner"/>.</typeparam>
+        /// <param name="runner">The function to be executed on the main loop.</param>
+        /// <returns>A task that completes with the result of <paramref name="runner"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="runner"/> is null.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static async Task<T> Post<T>(Func<T> runner)
         {
             Log.Info(LogTag, $"TeamCoreApplication.Post<T>() called - Type: {typeof(T).Name}");

--- a/src/Tizen.Applications.Team/TeamCoreUiApplication.cs
+++ b/src/Tizen.Applications.Team/TeamCoreUiApplication.cs
@@ -16,24 +16,60 @@
 
 
 using System;
+using System.ComponentModel;
 using Tizen.Applications.CoreBackend;
 using Tizen.NUI;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents a base class for Team UI applications that own a NUI <see cref="Window"/> and expose
+    /// <see cref="Resumed"/> and <see cref="Paused"/> lifecycle events.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamCoreUiApplication : TeamCoreApplication
     {
+        /// <summary>
+        /// Initializes the <see cref="TeamCoreUiApplication"/> class.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamCoreUiApplication() : base(new TeamUICoreBackend())
         {
         }
 
+        /// <summary>
+        /// Gets the default window of this application.
+        /// </summary>
+        /// <returns>The default <see cref="Window"/> associated with this application.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Window GetDefaultWindow()
         {
             return ((TeamUICoreBackend)Backend).GetDefaultWindow();
         }
 
+        /// <summary>
+        /// Occurs whenever the application is resumed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Resumed;
+
+        /// <summary>
+        /// Occurs whenever the application is paused.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Paused;
+
+        /// <summary>
+        /// Runs the Team UI application's main loop.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Run(string[] args)
         {
             Backend.AddEventHandler(EventType.Resumed, OnResume);
@@ -42,14 +78,31 @@ namespace Tizen.Applications
             base.Run(args);
         }
 
+        /// <summary>
+        /// Invoked when the application is created.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected override void OnCreate()
         {
-          base.OnCreate();
+            base.OnCreate();
         }
+
+        /// <summary>
+        /// Invoked when the application is resumed. Raises the <see cref="Resumed"/> event.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnResume()
         {
             Resumed?.Invoke(this, EventArgs.Empty);
         }
+
+        /// <summary>
+        /// Invoked when the application is paused. Raises the <see cref="Paused"/> event.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnPause()
         {
             Paused?.Invoke(this, EventArgs.Empty);

--- a/src/Tizen.Applications.Team/TeamDirectoryInfo.cs
+++ b/src/Tizen.Applications.Team/TeamDirectoryInfo.cs
@@ -22,6 +22,15 @@ using Tizen.Internals.Errors;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents the directory paths available to a Team application instance.
+    /// </summary>
+    /// <remarks>
+    /// Each path is resolved lazily on first access and cached. Any failure in the native call is translated
+    /// into a .NET exception; see each property for the specific exceptions that can be thrown.
+    /// </remarks>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamDirectoryInfo
     {
         private IntPtr _memberHandle;
@@ -45,6 +54,16 @@ namespace Tizen.Applications
             _memberHandle = memberHandle;
         }
 
+        /// <summary>
+        /// Gets the absolute path to the private data directory of this Team application.
+        /// </summary>
+        /// <value>The private data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Data
         {
             get
@@ -60,6 +79,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the private cache directory of this Team application.
+        /// </summary>
+        /// <value>The private cache directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Cache
         {
             get
@@ -75,6 +104,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the read-only resource directory of this Team application.
+        /// </summary>
+        /// <value>The read-only resource directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string Resource
         {
             get
@@ -90,6 +129,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the directory shared with other applications.
+        /// </summary>
+        /// <value>The shared data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedData
         {
             get
@@ -105,6 +154,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the read-only resource directory shared with other applications.
+        /// </summary>
+        /// <value>The shared resource directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedResource
         {
             get
@@ -120,6 +179,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the directory shared only with trusted applications.
+        /// </summary>
+        /// <value>The shared trusted directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string SharedTrusted
         {
             get
@@ -135,6 +204,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the private data directory on the external storage.
+        /// </summary>
+        /// <value>The external data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExternalData
         {
             get
@@ -150,6 +229,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the private cache directory on the external storage.
+        /// </summary>
+        /// <value>The external cache directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExternalCache
         {
             get
@@ -165,6 +254,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the shared directory on the external storage.
+        /// </summary>
+        /// <value>The external shared data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExternalSharedData
         {
             get
@@ -180,6 +279,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the resource directory of the Tizen Expansion Package.
+        /// </summary>
+        /// <value>The expansion package resource directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ExpansionPackageResource
         {
             get
@@ -195,6 +304,14 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the common data directory shared among users.
+        /// </summary>
+        /// <value>The common data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonData
         {
@@ -211,6 +328,14 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the common cache directory shared among users.
+        /// </summary>
+        /// <value>The common cache directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonCache
         {
@@ -227,6 +352,14 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the common shared data directory shared among users.
+        /// </summary>
+        /// <value>The common shared data directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedData
         {
@@ -243,6 +376,14 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the common shared trusted directory shared among users.
+        /// </summary>
+        /// <value>The common shared trusted directory path.</value>
+        /// <exception cref="ArgumentException">Thrown when the member handle is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedTrusted
         {
@@ -259,6 +400,17 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the absolute path to the resource directory allowed by resource control for the given resource type.
+        /// </summary>
+        /// <param name="resType">The resource type.</param>
+        /// <returns>The path to the allowed resource directory.</returns>
+        /// <exception cref="ArgumentException">Thrown when the member handle or <paramref name="resType"/> is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string GetResourceControlAllowedResource(string resType)
         {
             Interop.TeamManager.TeamAppErrorCode err = Interop.TeamManager.TeamAppGetResControlAllowedPath(_memberHandle, resType, out string path);
@@ -267,6 +419,17 @@ namespace Tizen.Applications
             return path;
         }
 
+        /// <summary>
+        /// Gets the absolute path to the global resource directory by resource control for the given resource type.
+        /// </summary>
+        /// <param name="resType">The resource type.</param>
+        /// <returns>The path to the global resource directory.</returns>
+        /// <exception cref="ArgumentException">Thrown when the member handle or <paramref name="resType"/> is invalid.</exception>
+        /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
+        /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string GetResourceControlGlobalResource(string resType)
         {
             Interop.TeamManager.TeamAppErrorCode err = Interop.TeamManager.TeamAppGetResControlGlobalPath(_memberHandle, resType, out string path);

--- a/src/Tizen.Applications.Team/TeamDirectoryInfo.cs
+++ b/src/Tizen.Applications.Team/TeamDirectoryInfo.cs
@@ -312,6 +312,7 @@ namespace Tizen.Applications
         /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonData
         {
@@ -336,6 +337,7 @@ namespace Tizen.Applications
         /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonCache
         {
@@ -360,6 +362,7 @@ namespace Tizen.Applications
         /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedData
         {
@@ -384,6 +387,7 @@ namespace Tizen.Applications
         /// <exception cref="OutOfMemoryException">Thrown when the system runs out of memory.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the team member context is invalid or the path cannot be retrieved.</exception>
         /// <exception cref="DirectoryNotFoundException">Thrown when the Team member is not found.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CommonSharedTrusted
         {

--- a/src/Tizen.Applications.Team/TeamLoop.cs
+++ b/src/Tizen.Applications.Team/TeamLoop.cs
@@ -16,6 +16,7 @@
 
 
 using System;
+using System.ComponentModel;
 using System.Threading;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -25,6 +26,11 @@ using Tizen.NUI;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Provides the entry point to the native Team main loop and the dynamic assembly load/unload callbacks.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TeamLoop
     {
         private const string LogTag = "DN_TAM";
@@ -42,6 +48,12 @@ namespace Tizen.Applications
             _ops.OnLoopCreate = new Interop.TeamLoop.TeamLoopOpsOnLoopCreate(DoOnLoopCreate);
             _ops.OnLoopTerminate = new Interop.TeamLoop.TeamLoopOpsOnLoopTerminate(DoOnLoopTerminate);
         }
+        /// <summary>
+        /// Starts the Team main loop. Subsequent calls while the loop is running are no-ops.
+        /// </summary>
+        /// <param name="args">Arguments passed to the native Team loop.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Run(string[] args)
         {
             Log.Info(LogTag, $"Run() called - Already Running: {_isRunning}");
@@ -69,6 +81,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Team main loop is currently running.
+        /// </summary>
+        /// <returns><c>true</c> if the main loop is running; otherwise, <c>false</c>.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool IsRunning()
         {
           Log.Info(LogTag, $"IsRunning() called - Result: {_isRunning}");
@@ -223,6 +241,12 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Gets the command line arguments that were passed to <see cref="Run(string[])"/>.
+        /// </summary>
+        /// <returns>The arguments array, or <c>null</c> if <see cref="Run(string[])"/> has not been invoked.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static string[] GetSystemArgs()
         {
             Log.Info(LogTag, $"GetSystemArgs() called - Count: {_systemArgs?.Length ?? 0}");

--- a/src/Tizen.Applications.Team/TeamManager.cs
+++ b/src/Tizen.Applications.Team/TeamManager.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.Loader;
 using Tizen.NUI.BaseComponents;
@@ -50,6 +51,11 @@ namespace Tizen.Applications
         public bool Owned { get; set; }
     }
 
+    /// <summary>
+    /// Provides registration and management of Team application instances, loaded assemblies, and view ownership.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TeamManager
     {
         private const string LogTag = "DN_TAM";
@@ -103,11 +109,23 @@ namespace Tizen.Applications
             return null;
         }
 
+        /// <summary>
+        /// Initializes the Team application runtime and starts the Team main loop.
+        /// </summary>
+        /// <param name="args">Arguments from commandline. May be <c>null</c>.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Init(string[] args)
         {
             TeamLoop.Run(args);
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the Team main loop has been initialized.
+        /// </summary>
+        /// <returns><c>true</c> if the Team main loop is running; otherwise, <c>false</c>.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool IsInit()
         {
             return TeamLoop.IsRunning();
@@ -177,6 +195,16 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Registers a <see cref="View"/> with the Team manager under the given application id.
+        /// </summary>
+        /// <param name="view">The view to register.</param>
+        /// <param name="appid">The application id that owns the view.</param>
+        /// <returns>A unique identifier assigned to the registered view.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="view"/> or <paramref name="appid"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="appid"/> has already been registered.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static int AddView(View view, string appid)
         {
             if (view == null)
@@ -200,6 +228,13 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Removes a view previously registered via <see cref="AddView"/>.
+        /// </summary>
+        /// <param name="id">The unique identifier returned from <see cref="AddView"/>.</param>
+        /// <returns><c>true</c> if the view was removed; <c>false</c> if no matching id was found.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool RemoveView(int id)
         {
             lock (_lock)
@@ -215,6 +250,14 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Claims ownership of the view registered under the given application id.
+        /// </summary>
+        /// <param name="appid">The application id that owns the view.</param>
+        /// <returns>The owned <see cref="View"/>, or <c>null</c> if the view is already owned or not found.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="appid"/> is null or empty.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static View OwnViewApp(string appid)
         {
             if (string.IsNullOrEmpty(appid))
@@ -241,6 +284,13 @@ namespace Tizen.Applications
             }
         }
 
+        /// <summary>
+        /// Releases ownership of the view registered under the given application id.
+        /// </summary>
+        /// <param name="appid">The application id that owns the view.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="appid"/> is null or empty.</exception>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void DisownViewApp(string appid)
         {
             if (string.IsNullOrEmpty(appid))

--- a/src/Tizen.Applications.Team/TeamServiceApplication.cs
+++ b/src/Tizen.Applications.Team/TeamServiceApplication.cs
@@ -15,18 +15,36 @@
  */
 
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Tizen.Applications.CoreBackend;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents a Team application that runs without a graphical user interface.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamServiceApplication : TeamCoreApplication
     {
+        /// <summary>
+        /// Initializes the <see cref="TeamServiceApplication"/> class.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
 #pragma warning disable CA2000
         public TeamServiceApplication() : base(new TeamServiceCoreBackend())
 #pragma warning restore CA2000
         {
         }
+
+        /// <summary>
+        /// Runs the Team service application's main loop.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Run(string[] args)
         {
             base.Run(args);

--- a/src/Tizen.Applications.Team/TeamUiApplication.cs
+++ b/src/Tizen.Applications.Team/TeamUiApplication.cs
@@ -15,15 +15,33 @@
  */
 
 using System;
+using System.ComponentModel;
 using Tizen.NUI;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents a Team application that provides a default NUI window.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamUiApplication : TeamCoreUiApplication
     {
+        /// <summary>
+        /// Initializes the <see cref="TeamUiApplication"/> class.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamUiApplication()
         {
         }
+
+        /// <summary>
+        /// Runs the Team UI application's main loop.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Run(string[] args)
         {
             base.Run(args);

--- a/src/Tizen.Applications.Team/TeamViewApplication.cs
+++ b/src/Tizen.Applications.Team/TeamViewApplication.cs
@@ -16,25 +16,63 @@
 
 
 using System;
+using System.ComponentModel;
 using Tizen.Applications.CoreBackend;
 using Tizen.NUI;
 using Tizen.NUI.BaseComponents;
 
 namespace Tizen.Applications
 {
+    /// <summary>
+    /// Represents a Team application that provides a default NUI <see cref="View"/>.
+    /// </summary>
+    /// <remarks>
+    /// A view application renders into a shared window supplied by the Team host rather than owning its own window.
+    /// </remarks>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class TeamViewApplication : TeamCoreApplication
     {
+        /// <summary>
+        /// Initializes the <see cref="TeamViewApplication"/> class.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public TeamViewApplication() : base(new TeamViewCoreBackend())
         {
         }
 
+        /// <summary>
+        /// Gets the default view attached to this application.
+        /// </summary>
+        /// <returns>The default <see cref="View"/> associated with this application.</returns>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public View GetDefaultView()
         {
             return ((TeamViewCoreBackend)Backend).GetDefaultView();
         }
 
+        /// <summary>
+        /// Occurs whenever the application is resumed.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Resumed;
+
+        /// <summary>
+        /// Occurs whenever the application is paused.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public event EventHandler Paused;
+
+        /// <summary>
+        /// Runs the Team view application's main loop.
+        /// </summary>
+        /// <param name="args">Arguments from commandline.</param>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void Run(string[] args)
         {
             Backend.AddEventHandler(EventType.Resumed, OnResume);
@@ -42,10 +80,22 @@ namespace Tizen.Applications
 
             base.Run(args);
         }
+
+        /// <summary>
+        /// Invoked when the application is resumed. Raises the <see cref="Resumed"/> event.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnResume()
         {
             Resumed?.Invoke(this, EventArgs.Empty);
         }
+
+        /// <summary>
+        /// Invoked when the application is paused. Raises the <see cref="Paused"/> event.
+        /// </summary>
+        /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void OnPause()
         {
             Paused?.Invoke(this, EventArgs.Empty);

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamCoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamCoreBackend.cs
@@ -15,14 +15,32 @@
  */
 
 using System;
+using System.ComponentModel;
 
 namespace Tizen.Applications.CoreBackend
 {
+    /// <summary>
+    /// Represents the abstract base backend that drives a Team application instance.
+    /// </summary>
+    /// This will be public opened in next tizen after ACR done. (Before ACR, need to be hidden as inhouse API)
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class TeamCoreBackend : DefaultCoreBackend
     {
+        /// <summary>
+        /// The native handle that identifies this Team member instance.
+        /// </summary>
         protected IntPtr _memberHandle = IntPtr.Zero;
+
+        /// <summary>
+        /// The identifier of the loaded assembly associated with this Team member instance.
+        /// </summary>
         protected IntPtr _loadObjId = IntPtr.Zero;
+
+        /// <summary>
+        /// The native handle to the arguments passed to this Team member instance.
+        /// </summary>
         protected IntPtr _argHandle = IntPtr.Zero;
+
         internal abstract IntPtr MemberHandle { get; }
         internal abstract IntPtr LoadObjId { get; }
         internal abstract IntPtr ArgHandle { get; }

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamServiceCoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamServiceCoreBackend.cs
@@ -19,6 +19,9 @@ using Tizen.Internals;
 
 namespace Tizen.Applications.CoreBackend
 {
+    /// <summary>
+    /// Backend implementation for Team service applications that run without a graphical UI.
+    /// </summary>
     internal class TeamServiceCoreBackend : TeamCoreBackend
     {
         internal new static string LogTag = "DN_TAM";

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamUICoreBackend.cs
@@ -20,6 +20,9 @@ using Tizen.NUI;
 
 namespace Tizen.Applications.CoreBackend
 {
+    /// <summary>
+    /// Backend implementation for Team UI applications that own a default <see cref="Window"/>.
+    /// </summary>
     internal class TeamUICoreBackend : TeamCoreBackend
     {
         internal new static string LogTag = "DN_TAM";

--- a/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamViewCoreBackend.cs
+++ b/src/Tizen.Applications.Team/Tizen.Applications.CoreBackend/TeamViewCoreBackend.cs
@@ -21,6 +21,9 @@ using Tizen.NUI.BaseComponents;
 
 namespace Tizen.Applications.CoreBackend
 {
+    /// <summary>
+    /// Backend implementation for Team view applications that render into a shared host-provided <see cref="View"/>.
+    /// </summary>
     internal class TeamViewCoreBackend : TeamCoreBackend
     {
         internal new static string LogTag = "DN_TAM";


### PR DESCRIPTION
- Add <summary>, <param>, <returns>, <exception>, <remarks> XML doc comments to public API surface of Tizen.Applications.Team module.
- Mark public types and members with [EditorBrowsable(EditorBrowsableState.Never)] and inhouse comment line until ACR is completed.
